### PR TITLE
Testing and Clean Up

### DIFF
--- a/nasa-exoplanet-query-app-tests/ExoPlanetDataModelTests.cs
+++ b/nasa-exoplanet-query-app-tests/ExoPlanetDataModelTests.cs
@@ -1,0 +1,59 @@
+
+namespace nasa_exoplanet_query_app {
+    public class ExoPlanetDataModelTests {
+        [Fact]
+        public void Constructor_Sets_Defaults() {
+            var model = new ExoPlanetDataModel();
+
+            Assert.NotNull(model.DiscYearStrings);
+            Assert.Single(model.DiscYearStrings);
+            Assert.Equal(ExoPlanetDataModel.NOT_SPECIFIED, model.DiscYearStrings[0]);
+            Assert.Equal(0, model.DiscYearSelectedIndex);
+
+            Assert.NotNull(model.DiscMethodStrings);
+            Assert.Single(model.DiscMethodStrings);
+            Assert.Equal(ExoPlanetDataModel.NOT_SPECIFIED, model.DiscMethodStrings[0]);
+            Assert.Equal(0, model.DiscMethodSelectedIndex);
+
+            Assert.NotNull(model.HostNameStrings);
+            Assert.Single(model.HostNameStrings);
+            Assert.Equal(ExoPlanetDataModel.NOT_SPECIFIED, model.HostNameStrings[0]);
+            Assert.Equal(0, model.HostNameSelectedIndex);
+
+            Assert.NotNull(model.DiscFacilityStrings);
+            Assert.Single(model.DiscFacilityStrings);
+            Assert.Equal(ExoPlanetDataModel.NOT_SPECIFIED, model.DiscFacilityStrings[0]);
+            Assert.Equal(0, model.DiscFacilitySelectedIndex);
+
+            Assert.NotNull(model.ExoPlanetCollection);
+            Assert.Empty(model.ExoPlanetCollection);
+        }
+
+        [Fact]
+        public void SettingProperties_RaisesPropertyChanged() {
+            var model = new ExoPlanetDataModel();
+            int events = 0;
+            var changedNames = new System.Collections.Generic.List<string>();
+
+            model.PropertyChanged += (sender, e) => {
+                events++;
+                changedNames.Add(e.PropertyName);
+            };
+
+            model.DiscYearSelectedIndex = 5;
+            model.DiscYearStrings = new[] { "h", "i" };
+            model.DiscMethodSelectedIndex = 2;
+            model.DiscMethodStrings = new[] { "m1", "m2" };
+            model.HostNameSelectedIndex = 1;
+            model.HostNameStrings = new[] { "a", "b" };
+            model.DiscFacilitySelectedIndex = 3;
+            model.DiscFacilityStrings = new[] { "f1", "f2" };
+            model.ExoPlanetCollection = new System.Collections.ObjectModel.ObservableCollection<ExoPlanetData>();
+
+            Assert.True(events >= 8);
+            Assert.Contains(nameof(model.DiscYearSelectedIndex), changedNames);
+            Assert.Contains(nameof(model.DiscYearStrings), changedNames);
+            Assert.Contains(nameof(model.ExoPlanetCollection), changedNames);
+        }
+    }
+}

--- a/nasa-exoplanet-query-app-tests/ExoPlanetDataModelTests.cs
+++ b/nasa-exoplanet-query-app-tests/ExoPlanetDataModelTests.cs
@@ -50,9 +50,15 @@ namespace nasa_exoplanet_query_app {
             model.DiscFacilityStrings = new[] { "f1", "f2" };
             model.ExoPlanetCollection = new System.Collections.ObjectModel.ObservableCollection<ExoPlanetData>();
 
-            Assert.True(events >= 8);
+            Assert.Equal(9, events); // One event for each property set
             Assert.Contains(nameof(model.DiscYearSelectedIndex), changedNames);
             Assert.Contains(nameof(model.DiscYearStrings), changedNames);
+            Assert.Contains(nameof(model.DiscMethodSelectedIndex), changedNames);
+            Assert.Contains(nameof(model.DiscMethodStrings), changedNames);
+            Assert.Contains(nameof(model.HostNameSelectedIndex), changedNames);
+            Assert.Contains(nameof(model.HostNameStrings), changedNames);
+            Assert.Contains(nameof(model.DiscFacilitySelectedIndex), changedNames);
+            Assert.Contains(nameof(model.DiscFacilityStrings), changedNames);
             Assert.Contains(nameof(model.ExoPlanetCollection), changedNames);
         }
     }

--- a/nasa-exoplanet-query-app-tests/ExoPlanetTAPHelperTests.cs
+++ b/nasa-exoplanet-query-app-tests/ExoPlanetTAPHelperTests.cs
@@ -6,23 +6,33 @@ namespace nasa_exoplanet_query_app {
 
         [Fact]
         public void GetPSHTTPRequestString_Constructs_SelectDistinct_OrderBy_And_Format() {
-            string result = ExoplanetTAPHelper.GetPSHTTPRequestString(ExoplanetTAPHelper.HOST_NAME, ExoplanetTAPHelper.FORMAT_CSV);
+            string result = ExoplanetTAPHelper.GetPSUniqueColumnValuesRequestString(ExoplanetTAPHelper.HOST_NAME, ExoplanetTAPHelper.FORMAT_CSV);
 
             string compact = Compact(result);
-            Assert.Contains("select+distinct+hostname", compact);
-            Assert.Contains("+from+ps", compact);
-            Assert.Contains("+order+by+hostname+asc", compact);
+            Assert.Contains($"select+distinct+{ExoplanetTAPHelper.HOST_NAME}", compact);
+            Assert.Contains($"+from+{ExoplanetTAPHelper.PlANETARY_SYSTEMS_TABLE}", compact);
+            Assert.Contains($"+order+by+{ExoplanetTAPHelper.HOST_NAME}+asc", compact);
             Assert.EndsWith(ExoplanetTAPHelper.FORMAT_CSV, result);
         }
 
         [Fact]
-        public void GetPSFilteredResultsRequestString_NoFilters_ProducesSelectAndFormat() {
+        public void GetPSFilteredResultsRequestString_NoFilters_ProducesNoWhereClause() {
             string ns = ExoPlanetDataModel.NOT_SPECIFIED;
             string result = ExoplanetTAPHelper.GetPSFilteredResultsRequestString(ns, ns, ns, ns);
+            Assert.True(result != null || result != string.Empty);
 
             string compact = Compact(result);
-            Assert.Contains("select+pl_name,", compact); // ensure select fields are present
-            Assert.DoesNotContain("where+", compact); // ensure there is no 'where' clause when all are NOT_SPECIFIED
+            // ensure select fields are present
+            Assert.Contains($"select+" +
+                            $"{ExoplanetTAPHelper.PLANET_NAME}," +
+                            $"{ExoplanetTAPHelper.HOST_NAME}," +
+                            $"{ExoplanetTAPHelper.DISC_FACILITY}," +
+                            $"{ExoplanetTAPHelper.DISC_YEAR}," +
+                            $"{ExoplanetTAPHelper.DISC_METHOD}," +
+                            $"{ExoplanetTAPHelper.STAR_COUNT}," +
+                            $"{ExoplanetTAPHelper.PLANET_COUNT}," +
+                            $"{ExoplanetTAPHelper.MOON_COUNT}+", compact);
+            Assert.DoesNotContain("where", compact); // ensure there is no 'where' clause when all are NOT_SPECIFIED
             Assert.EndsWith(ExoplanetTAPHelper.FORMAT_JSON, result);
         }
 
@@ -33,23 +43,14 @@ namespace nasa_exoplanet_query_app {
             string year = "2000";
             string method = "Transit";
 
-            string result = ExoplanetTAPHelper.GetPSFilteredResultsRequestString(host, facility, year, method, "&format=csv");
+            string result = ExoplanetTAPHelper.GetPSFilteredResultsRequestString(host, facility, year, method, ExoplanetTAPHelper.FORMAT_JSON);
             string compact = Compact(result);
 
             Assert.Contains($"where+{ExoplanetTAPHelper.HOST_NAME}='{host}'+", compact);
             Assert.Contains($"and+{ExoplanetTAPHelper.DISC_FACILITY}='{facility}'+", compact);
             Assert.Contains($"and+{ExoplanetTAPHelper.DISC_YEAR}='{year}'+", compact);
             Assert.Contains($"and+{ExoplanetTAPHelper.DISC_METHOD}='{method}'+", compact);
-            Assert.EndsWith("&format=csv", result);
-        }
-
-        [Fact]
-        public void GetPSDiscYearValuesString_AppendsFormatWhenProvided() {
-            string baseResult = ExoplanetTAPHelper.GetPSDiscYearValuesString();
-            Assert.Contains("select+distinct+disc_year+from+ps+order+by+disc_year+asc", Compact(baseResult));
-
-            string withFormat = ExoplanetTAPHelper.GetPSDiscYearValuesString("&format=csv");
-            Assert.EndsWith("&format=csv", withFormat);
+            Assert.EndsWith(ExoplanetTAPHelper.FORMAT_JSON, result);
         }
     }
 }

--- a/nasa-exoplanet-query-app-tests/ExoPlanetTAPHelperTests.cs
+++ b/nasa-exoplanet-query-app-tests/ExoPlanetTAPHelperTests.cs
@@ -1,0 +1,55 @@
+using System.Text.RegularExpressions;
+
+namespace nasa_exoplanet_query_app {
+    public class ExoplanetTAPHelperTests {
+        private static string Compact(string s) => Regex.Replace(s ?? string.Empty, @"\s+", "");
+
+        [Fact]
+        public void GetPSHTTPRequestString_Constructs_SelectDistinct_OrderBy_And_Format() {
+            string result = ExoplanetTAPHelper.GetPSHTTPRequestString(ExoplanetTAPHelper.HOST_NAME, ExoplanetTAPHelper.FORMAT_CSV);
+
+            string compact = Compact(result);
+            Assert.Contains("select+distinct+hostname", compact);
+            Assert.Contains("+from+ps", compact);
+            Assert.Contains("+order+by+hostname+asc", compact);
+            Assert.EndsWith(ExoplanetTAPHelper.FORMAT_CSV, result);
+        }
+
+        [Fact]
+        public void GetPSFilteredResultsRequestString_NoFilters_ProducesSelectAndFormat() {
+            string ns = ExoPlanetDataModel.NOT_SPECIFIED;
+            string result = ExoplanetTAPHelper.GetPSFilteredResultsRequestString(ns, ns, ns, ns);
+
+            string compact = Compact(result);
+            Assert.Contains("select+pl_name,", compact); // ensure select fields are present
+            Assert.DoesNotContain("where+", compact); // ensure there is no 'where' clause when all are NOT_SPECIFIED
+            Assert.EndsWith(ExoplanetTAPHelper.FORMAT_JSON, result);
+        }
+
+        [Fact]
+        public void GetPSFilteredResultsRequestString_WithFilters_AppendsWhereAndAndCorrectly() {
+            string host = "HOST1";
+            string facility = "FAC1";
+            string year = "2000";
+            string method = "Transit";
+
+            string result = ExoplanetTAPHelper.GetPSFilteredResultsRequestString(host, facility, year, method, "&format=csv");
+            string compact = Compact(result);
+
+            Assert.Contains($"where+{ExoplanetTAPHelper.HOST_NAME}='{host}'+", compact);
+            Assert.Contains($"and+{ExoplanetTAPHelper.DISC_FACILITY}='{facility}'+", compact);
+            Assert.Contains($"and+{ExoplanetTAPHelper.DISC_YEAR}='{year}'+", compact);
+            Assert.Contains($"and+{ExoplanetTAPHelper.DISC_METHOD}='{method}'+", compact);
+            Assert.EndsWith("&format=csv", result);
+        }
+
+        [Fact]
+        public void GetPSDiscYearValuesString_AppendsFormatWhenProvided() {
+            string baseResult = ExoplanetTAPHelper.GetPSDiscYearValuesString();
+            Assert.Contains("select+distinct+disc_year+from+ps+order+by+disc_year+asc", Compact(baseResult));
+
+            string withFormat = ExoplanetTAPHelper.GetPSDiscYearValuesString("&format=csv");
+            Assert.EndsWith("&format=csv", withFormat);
+        }
+    }
+}

--- a/nasa-exoplanet-query-app-tests/MainWindowViewModelTests.cs
+++ b/nasa-exoplanet-query-app-tests/MainWindowViewModelTests.cs
@@ -1,0 +1,24 @@
+using System.Reflection;
+
+namespace nasa_exoplanet_query_app {
+    public class MainWindowViewModelTests {
+        [Fact]
+        public void CopyArrayValuesToDropDown_Produces_NotSpecified_First_And_Preserves_Others() {
+            // Create instance without invoking constructor to avoid network-populating side effects
+            var ctor = typeof(MainWindowViewModel).GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public, null, Type.EmptyTypes, null);
+            Assert.NotNull(ctor);
+            var vm = (MainWindowViewModel)ctor.Invoke(null);
+
+            var method = typeof(MainWindowViewModel).GetMethod("CopyArrayValuesToDropDown", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(method);
+
+            string[] input = new[] { "Header", "Alpha", "Beta" };
+            var result = (string[])method.Invoke(vm, new object[] { input })!;
+
+            Assert.Equal(input.Length, result.Length);
+            Assert.Equal(ExoPlanetDataModel.NOT_SPECIFIED, result[0]);
+            Assert.Equal("Alpha", result[1]);
+            Assert.Equal("Beta", result[2]);
+        }
+    }
+}

--- a/nasa-exoplanet-query-app-tests/MainWindowViewModelTests.cs
+++ b/nasa-exoplanet-query-app-tests/MainWindowViewModelTests.cs
@@ -2,23 +2,31 @@ using System.Reflection;
 
 namespace nasa_exoplanet_query_app {
     public class MainWindowViewModelTests {
-        [Fact]
-        public void CopyArrayValuesToDropDown_Produces_NotSpecified_First_And_Preserves_Others() {
+        [Theory]
+        [InlineData()]
+        [InlineData("Header", "Alpha", "Beta")]
+        [InlineData("Header", "Alpha", "Beta", "Gamma", "Delta", "Epsilon")]
+        [InlineData(null, null, null, null)]
+        [InlineData("Header", "Alpha", null, "Gamma", "Delta", null)]
+        public void CopyArrayValuesToDropDown_Produces_NotSpecified_First_And_Preserves_Others(params string[] inputStrings) {
             // Create instance without invoking constructor to avoid network-populating side effects
-            var ctor = typeof(MainWindowViewModel).GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public, null, Type.EmptyTypes, null);
+            // like PopulateDropdownFields() being called.
+            BindingFlags ctorBindingFlags = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public;
+            var ctor = typeof(MainWindowViewModel).GetConstructor(ctorBindingFlags, null, Type.EmptyTypes, null);
             Assert.NotNull(ctor);
             var vm = (MainWindowViewModel)ctor.Invoke(null);
 
-            var method = typeof(MainWindowViewModel).GetMethod("CopyArrayValuesToDropDown", BindingFlags.Instance | BindingFlags.NonPublic);
-            Assert.NotNull(method);
+            BindingFlags pvtMethodBindingFlags = BindingFlags.Instance | BindingFlags.NonPublic;
+            var copyValuesMethod = typeof(MainWindowViewModel).GetMethod("CopyArrayValuesToDropDown", pvtMethodBindingFlags);
+            Assert.NotNull(copyValuesMethod);
 
-            string[] input = new[] { "Header", "Alpha", "Beta" };
-            var result = (string[])method.Invoke(vm, new object[] { input })!;
+            var result = (string[])copyValuesMethod.Invoke(vm, new object[] { inputStrings })!;
 
-            Assert.Equal(input.Length, result.Length);
+            Assert.True(result.Length > 0); // array should have at least one element for "N/S"
             Assert.Equal(ExoPlanetDataModel.NOT_SPECIFIED, result[0]);
-            Assert.Equal("Alpha", result[1]);
-            Assert.Equal("Beta", result[2]);
+            for (int i = 1; i < inputStrings.Length; i++) {
+                Assert.Equal(inputStrings[i], result[i]);
+            }
         }
     }
 }

--- a/nasa-exoplanet-query-app-tests/nasa-exoplanet-query-app-tests.csproj
+++ b/nasa-exoplanet-query-app-tests/nasa-exoplanet-query-app-tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <RootNamespace>nasa_exoplanet_query_app_tests</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\nasa-exoplanet-query-app\nasa-exoplanet-query-app.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/nasa-exoplanet-query-app.sln
+++ b/nasa-exoplanet-query-app.sln
@@ -1,9 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.14.36414.22 d17.14
+VisualStudioVersion = 17.14.36414.22
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "nasa-exoplanet-query-app", "nasa-exoplanet-query-app\nasa-exoplanet-query-app.csproj", "{418B4F58-0345-42E8-8988-ED1EE190FD90}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "nasa-exoplanet-query-app-tests", "nasa-exoplanet-query-app-tests\nasa-exoplanet-query-app-tests.csproj", "{8CAD8BC7-76DF-4C40-AB00-6CA4B346E18C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{418B4F58-0345-42E8-8988-ED1EE190FD90}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{418B4F58-0345-42E8-8988-ED1EE190FD90}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{418B4F58-0345-42E8-8988-ED1EE190FD90}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8CAD8BC7-76DF-4C40-AB00-6CA4B346E18C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8CAD8BC7-76DF-4C40-AB00-6CA4B346E18C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8CAD8BC7-76DF-4C40-AB00-6CA4B346E18C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8CAD8BC7-76DF-4C40-AB00-6CA4B346E18C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/nasa-exoplanet-query-app/ExoPlanetDataModel.cs
+++ b/nasa-exoplanet-query-app/ExoPlanetDataModel.cs
@@ -1,0 +1,104 @@
+using System.Collections.ObjectModel;
+
+namespace nasa_exoplanet_query_app {
+    public class ExoPlanetDataModel : ModelBase {
+        public const string NOT_SPECIFIED = "N/S";
+
+        private int mDiscYearSelectedIndex;
+        public int DiscYearSelectedIndex {
+            get => mDiscYearSelectedIndex;
+            set {
+                mDiscYearSelectedIndex = value;
+                OnPropertyChanged();
+            }
+        }
+
+        private string[] mDiscYearStrings;
+        public string[] DiscYearStrings {
+            get => mDiscYearStrings;
+            set {
+                mDiscYearStrings = value;
+                OnPropertyChanged();
+            }
+        }
+
+        private int mDiscMethodSelectedIndex;
+        public int DiscMethodSelectedIndex {
+            get => mDiscMethodSelectedIndex;
+            set {
+                mDiscMethodSelectedIndex = value;
+                OnPropertyChanged();
+            }
+        }
+
+        private string[] mDiscMethodStrings;
+        public string[] DiscMethodStrings {
+            get => mDiscMethodStrings;
+            set {
+                mDiscMethodStrings = value;
+                OnPropertyChanged();
+            }
+        }
+
+        private int mHostNameSelectedIndex;
+        public int HostNameSelectedIndex {
+            get => mHostNameSelectedIndex;
+            set {
+                mHostNameSelectedIndex = value;
+                OnPropertyChanged();
+            }
+        }
+
+        private string[] mHostNameStrings;
+        public string[] HostNameStrings {
+            get => mHostNameStrings;
+            set {
+                mHostNameStrings = value;
+                OnPropertyChanged();
+            }
+        }
+
+        private int mDiscFacilitySelectedIndex;
+        public int DiscFacilitySelectedIndex {
+            get => mDiscFacilitySelectedIndex;
+            set {
+                mDiscFacilitySelectedIndex = value;
+                OnPropertyChanged();
+            }
+        }
+
+        private string[] mDiscFacilityStrings;
+        public string[] DiscFacilityStrings {
+            get => mDiscFacilityStrings;
+            set {
+                mDiscFacilityStrings = value;
+                OnPropertyChanged();
+            }
+        }
+
+        private ObservableCollection<ExoPlanetData> mExoPlanetCollection;
+        public ObservableCollection<ExoPlanetData> ExoPlanetCollection {
+            get => mExoPlanetCollection;
+            set {
+                mExoPlanetCollection = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public ExoPlanetDataModel() {
+            mDiscYearStrings = [NOT_SPECIFIED];
+            mDiscYearSelectedIndex = 0;
+
+            mDiscMethodStrings = [NOT_SPECIFIED];
+            mDiscMethodSelectedIndex = 0;
+
+            mHostNameStrings = [NOT_SPECIFIED];
+            mHostNameSelectedIndex = 0;
+
+            mDiscFacilityStrings = [NOT_SPECIFIED];
+            mDiscFacilitySelectedIndex = 0;
+
+            mExoPlanetCollection = new ObservableCollection<ExoPlanetData>();
+        }
+    }
+}

--- a/nasa-exoplanet-query-app/ExoplanetQueryHelper.cs
+++ b/nasa-exoplanet-query-app/ExoplanetQueryHelper.cs
@@ -48,7 +48,7 @@ namespace nasa_exoplanet_query_app {
 
             bool isFirstFilter = true;
             // append the appropriate where clauses based on the currently selected filters
-            if (hostName != MainWindowViewModel.NOT_SPECIFIED) {
+            if (hostName != ExoPlanetDataModel.NOT_SPECIFIED) {
                 if (isFirstFilter) {
                     isFirstFilter = false;
                     requestString += $"where+{HOST_NAME}='{hostName}'+";
@@ -59,7 +59,7 @@ namespace nasa_exoplanet_query_app {
                 }
             }
 
-            if (discFacility != MainWindowViewModel.NOT_SPECIFIED) {
+            if (discFacility != ExoPlanetDataModel.NOT_SPECIFIED) {
                 if (isFirstFilter) {
                     isFirstFilter = false;
                     requestString += $"where+{DISC_FACILITY}='{discFacility}'+";
@@ -70,7 +70,7 @@ namespace nasa_exoplanet_query_app {
                 }
             }
 
-            if (discYear != MainWindowViewModel.NOT_SPECIFIED) {
+            if (discYear != ExoPlanetDataModel.NOT_SPECIFIED) {
                 if (isFirstFilter) {
                     isFirstFilter = false;
                     requestString += $"where+{DISC_YEAR}='{discYear}'+";
@@ -81,7 +81,7 @@ namespace nasa_exoplanet_query_app {
                 }
             }
 
-            if (discMethod != MainWindowViewModel.NOT_SPECIFIED) {
+            if (discMethod != ExoPlanetDataModel.NOT_SPECIFIED) {
                 if (isFirstFilter) {
                     isFirstFilter = false;
                     requestString += $"where+{DISC_METHOD}='{discMethod}'+";

--- a/nasa-exoplanet-query-app/ExoplanetQueryHelper.cs
+++ b/nasa-exoplanet-query-app/ExoplanetQueryHelper.cs
@@ -21,14 +21,14 @@ namespace nasa_exoplanet_query_app {
         public const string FORMAT_CSV = "&format=csv";
         public const string FORMAT_JSON = "&format=json";
 
-        // selectParam must be separated by comma if multiple
-        // TODO: change distinct to use group by
-        public static string GetPSHTTPRequestString(string selectParam = "*", string format = "") {
-            string requestString = $"{EXOPLANET_ARCHIVE_BASE_URL}" +
-                                   $"select+distinct+{selectParam}" +
-                                   $"+from+{PlANETARY_SYSTEMS_TABLE}" +
-                                   $"+order+by+{selectParam}+asc" +
-                                   $"{format}";
+        // retrieves the unique values for the requested column(s) in the Planetary Systems table,
+        // ordered ascending alphabetically, in the format specified (default is CSV)
+        public static string GetPSUniqueColumnValuesRequestString(string selectParam = "*", string format = FORMAT_CSV) {
+            string requestString = @$"{EXOPLANET_ARCHIVE_BASE_URL}
+                                       select+distinct+{selectParam}
+                                       +from+{PlANETARY_SYSTEMS_TABLE}
+                                       +order+by+{selectParam}+asc
+                                       {format}";
 
             return requestString;
         }
@@ -93,18 +93,6 @@ namespace nasa_exoplanet_query_app {
             }
 
             requestString += format; // append the file format
-
-            return requestString;
-        }
-
-        // Builds a http request string that queries the Planetary System table for unique discovery years in ascending order
-        public static string GetPSDiscYearValuesString(string format = "") {
-            string requestString = EXOPLANET_ARCHIVE_BASE_URL +
-                                   "select+distinct+disc_year+from+ps+order+by+disc_year+asc";
-
-            if (!String.IsNullOrEmpty(format)) {
-                requestString += format;
-            }
 
             return requestString;
         }

--- a/nasa-exoplanet-query-app/MainWindow.xaml
+++ b/nasa-exoplanet-query-app/MainWindow.xaml
@@ -41,24 +41,28 @@
                 x:Name="DiscYearSelection"
                 Grid.Column="1"
                 Grid.Row="0"
+                DataContext="{Binding EPModel}"
                 ItemsSource="{Binding DiscYearStrings}"
                 SelectedIndex="{Binding DiscYearSelectedIndex}"/>
             <ComboBox
                 x:Name="DiscMethodSelection"
                 Grid.Column="1"
                 Grid.Row="1"
+                DataContext="{Binding EPModel}"
                 ItemsSource="{Binding DiscMethodStrings}"
                 SelectedIndex="{Binding DiscMethodSelectedIndex}"/>
             <ComboBox
                 x:Name="HostNameSelection"
                 Grid.Column="1"
                 Grid.Row="2"
+                DataContext="{Binding EPModel}"
                 ItemsSource="{Binding HostNameStrings}"
                 SelectedIndex="{Binding HostNameSelectedIndex}"/>
             <ComboBox
                 x:Name="DiscFacilitySelection"
                 Grid.Column="1"
                 Grid.Row="3"
+                DataContext="{Binding EPModel}"
                 ItemsSource="{Binding DiscFacilityStrings}"
                 SelectedIndex="{Binding DiscFacilitySelectedIndex}"/>
 
@@ -75,6 +79,7 @@
                 Grid.Column="0"
                 Grid.Row="5"
                 Grid.ColumnSpan="2"
+                DataContext="{Binding EPModel}"
                 ItemsSource="{Binding ExoPlanetCollection}"
                 AutoGenerateColumns="True"
                 CanUserAddRows="False"

--- a/nasa-exoplanet-query-app/MainWindow.xaml.cs
+++ b/nasa-exoplanet-query-app/MainWindow.xaml.cs
@@ -18,33 +18,8 @@ namespace nasa_exoplanet_query_app {
             DataContext = vm;
         }
 
-        private void GetResultsFromPlanetarySystems() {
-            string requestString = ExoplanetTAPHelper.GetPSFilteredResultsRequestString(vm.HostNameStrings[vm.HostNameSelectedIndex],
-                                                                                        vm.DiscFacilityStrings[vm.DiscFacilitySelectedIndex],
-                                                                                        vm.DiscYearStrings[vm.DiscYearSelectedIndex],
-                                                                                        vm.DiscMethodStrings[vm.DiscMethodSelectedIndex]);
-
-            Task.Run(async () => {
-                HttpClient client = new HttpClient();
-                string response = await client.GetStringAsync(requestString);
-
-                try {
-                    var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
-                    var data = JsonSerializer.Deserialize<List<ExoPlanetData>>(response, options);
-
-                    if (data != null) {
-                        vm.ExoPlanetCollection = new ObservableCollection<ExoPlanetData>(data);
-                    }
-                }
-                catch (JsonException ex) {
-                    MessageBox.Show($"JSON Error: {ex.Message}\n\nResponse preview: {response.Substring(0, Math.Min(200, response.Length))}");
-                    System.Diagnostics.Debug.WriteLine($"Full response: {response}");
-                }
-            });
-        }
-
         private void PS_Table_Refresh_Button_Click(object sender, RoutedEventArgs e) {
-            GetResultsFromPlanetarySystems();
+            vm.GetResultsFromPlanetarySystems();
         }
     }
 }

--- a/nasa-exoplanet-query-app/MainWindowViewModel.cs
+++ b/nasa-exoplanet-query-app/MainWindowViewModel.cs
@@ -34,10 +34,10 @@ namespace nasa_exoplanet_query_app {
         }
 
         private void PopulateDropdownFields() {
-            string requestHostName = ExoplanetTAPHelper.GetPSHTTPRequestString(ExoplanetTAPHelper.HOST_NAME, ExoplanetTAPHelper.FORMAT_CSV);
-            string requestDiscFacility = ExoplanetTAPHelper.GetPSHTTPRequestString(ExoplanetTAPHelper.DISC_FACILITY, ExoplanetTAPHelper.FORMAT_CSV);
-            string requestDiscYear = ExoplanetTAPHelper.GetPSHTTPRequestString(ExoplanetTAPHelper.DISC_YEAR, ExoplanetTAPHelper.FORMAT_CSV);
-            string requestDiscMethod = ExoplanetTAPHelper.GetPSHTTPRequestString(ExoplanetTAPHelper.DISC_METHOD, ExoplanetTAPHelper.FORMAT_CSV);
+            string requestHostName = ExoplanetTAPHelper.GetPSUniqueColumnValuesRequestString(ExoplanetTAPHelper.HOST_NAME, ExoplanetTAPHelper.FORMAT_CSV);
+            string requestDiscFacility = ExoplanetTAPHelper.GetPSUniqueColumnValuesRequestString(ExoplanetTAPHelper.DISC_FACILITY, ExoplanetTAPHelper.FORMAT_CSV);
+            string requestDiscYear = ExoplanetTAPHelper.GetPSUniqueColumnValuesRequestString(ExoplanetTAPHelper.DISC_YEAR, ExoplanetTAPHelper.FORMAT_CSV);
+            string requestDiscMethod = ExoplanetTAPHelper.GetPSUniqueColumnValuesRequestString(ExoplanetTAPHelper.DISC_METHOD, ExoplanetTAPHelper.FORMAT_CSV);
 
             Task.Run(async () => {
                 HttpClient client = new HttpClient();

--- a/nasa-exoplanet-query-app/MainWindowViewModel.cs
+++ b/nasa-exoplanet-query-app/MainWindowViewModel.cs
@@ -17,6 +17,10 @@ namespace nasa_exoplanet_query_app {
         }
 
         private string[] CopyArrayValuesToDropDown(string[] values) {
+            if (values.Length == 0) {
+                return new string[] { ExoPlanetDataModel.NOT_SPECIFIED };
+            }
+
             // values length should be the number of unique values plus the column header, so unnecessary to add 1 for Not Specified
             string[] newStrings = new string[values.Length];
             newStrings[0] = ExoPlanetDataModel.NOT_SPECIFIED; // Set the first value to Not Specifieds
@@ -52,7 +56,7 @@ namespace nasa_exoplanet_query_app {
             Task.Run(async () => {
                 HttpClient client = new HttpClient();
                 string response = await client.GetStringAsync(requestDiscYear);
-                string[] values = response.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+                string[] values = response.Split('\n', StringSplitOptions.RemoveEmptyEntries); // elements are returned as numbers, no double quotes
                 EPModel.DiscYearStrings = CopyArrayValuesToDropDown(values);
             });
             Task.Run(async () => {

--- a/nasa-exoplanet-query-app/ModelBase.cs
+++ b/nasa-exoplanet-query-app/ModelBase.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace nasa_exoplanet_query_app {
+    public abstract class ModelBase : INotifyPropertyChanged {
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        protected void OnPropertyChanged([CallerMemberName] string? name = null) {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+        }
+    }
+}


### PR DESCRIPTION
- [EXOP-14](https://trello.com/c/9hU3TcGq/6-exop-14-realign-project-with-mvvm) enforce stricter adherence to the mvvm pattern
- [EXOP-12](https://trello.com/c/GNLaGqHV/4-exop-12-add-unit-testing-for-queries) Introduce base coverage unit testing (for MainWindowViewModel.cs, ExoPlanetDataModel.cs, ExoPlanetTAPHelper.cs) using copilot suggestions, then improve/clean up and of the tests while also making small changes to any issues that the tests uncovered